### PR TITLE
refactor issue labels to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
 | `issue-number` | Issue number to process | Yes | - |
 | `text-body` | Text body to check | Yes | - |
 | `checklist-key` | Key to identify checklist section | Yes | - |
-| `issue-labels` | JSON array of issue labels | Yes | - |
+| `issue-labels` | JSON array of issue labels | No | - |
 | `run-check-label` | Label indicating checklist present. Provides early exit to the script if label is not found. | No | - |
 | `incomplete-label` | Label indicating checklist incomplete | No | - |
 | `completed-label` | Label to add when checklist is completed | No | - |

--- a/action.yml
+++ b/action.yml
@@ -82,7 +82,13 @@ runs:
         echo "status=skipped" >> $GITHUB_OUTPUT
         echo "message=No action taken" >> $GITHUB_OUTPUT
 
-        LABEL_NAMES=$(echo "${LABELS}" | jq 'map(.name // empty)') 
+        if [[ -z "${LABELS}" ]]; then
+          echo "No labels provided. Attempting to fetch labels from the issue."
+          LABEL_NAMES=$(gh label list --json name | jq 'map(.name // empty)')
+        else
+          LABEL_NAMES=$(echo "${LABELS}" | jq 'map(.name // empty)') 
+        fi
+
         if [[ -z "${RUN_CHECK_LABEL}" ]] || echo "${LABEL_NAMES}" | grep -wq "${RUN_CHECK_LABEL}"; then
           # Extract the checklist section
           CHECKLIST_SECTION=$(echo "${TEXT_BODY}" | sed -n "/<!-- key=\"${CHECKLIST_KEY}\" value=\"start\" -->/,/<!-- key=\"${CHECKLIST_KEY}\" value=\"end\" -->/p")

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
 
         if [[ -z "${LABELS}" ]]; then
           echo "No labels provided. Attempting to fetch labels from the issue."
-          LABEL_NAMES=$(gh label list --json name | jq 'map(.name // empty)')
+          LABEL_NAMES=$(gh issue view $ISSUE_NUMBER --json labels --jq '.labels[].name')
         else
           LABEL_NAMES=$(echo "${LABELS}" | jq 'map(.name // empty)') 
         fi


### PR DESCRIPTION
### Description
refactored so `issue-labels` variable is optional. If not supplied then labels are attempted to be fetched via `gh label list` command.